### PR TITLE
Added Centre-of-Mass functionality and detector config files

### DIFF
--- a/prototypes/dectris.toml
+++ b/prototypes/dectris.toml
@@ -1,0 +1,8 @@
+detector_type = "dectris"
+
+[connection_arguments]
+api_host='localhost'
+api_port=8910
+data_host='localhost'
+data_port=9999
+buffer_size=2048

--- a/prototypes/live_server.py
+++ b/prototypes/live_server.py
@@ -581,10 +581,7 @@ class WSServer:
                 num_updates = 0
                 partial_results = None
 
-                if self.detector_type == "merlin":
-                    side = 256
-                else:
-                    side = int(math.sqrt(pending_aq.detector_config.get_num_frames()))
+                side = int(math.sqrt(pending_aq.nimages))
 
                 aq = self.ctx.make_acquisition(
                     conn=self.conn,
@@ -655,9 +652,6 @@ class WSServer:
         conn = ctx.make_connection(detector_settings["detector_type"]).open(
             **detector_settings["connection_arguments"]
         )
-        
-        # Temp fix for acquisition_loop when finding `side`
-        self.detector_type = detector_settings["detector_type"]
 
         self.conn = conn
         self.ctx = ctx

--- a/prototypes/merlin.toml
+++ b/prototypes/merlin.toml
@@ -1,0 +1,3 @@
+detector_type = "merlin"
+
+[connection_arguments]

--- a/prototypes/trigger_merlin.py
+++ b/prototypes/trigger_merlin.py
@@ -1,0 +1,8 @@
+from libertem_live.detectors.merlin.control import MerlinControl
+
+
+if __name__ == "__main__":
+    mc = MerlinControl()#"localhost", port=8910)
+    with mc:
+        mc.cmd("startacquisition")
+        mc.cmd("softtrigger")


### PR DESCRIPTION
This PR exposes centre-of-mass UDF from LiberTEM into the live server, making it possible to do descan corrected CoM 
 in live data acquisition. Very useful for cases with severe descan that can drown out the desired, nonlinear signal.

The PR also makes it possible to trigger Merlin detectors. Additionally, it's now possible to change detectors with the command line. With it, there are two detector config files, `merlin.toml` and `dectris.toml`, which can be supplied as an argument to use their respective simulated detectors.

Note the Merlin detector has some issues with EOF errors that are yet to be relieved.